### PR TITLE
EZP-23171: delete() must accept arrays for 2.0

### DIFF
--- a/classes/dfs/amazon.php
+++ b/classes/dfs/amazon.php
@@ -147,12 +147,19 @@ class eZDFSFileHandlerDFSAmazon implements eZDFSFileHandlerDFSBackendInterface, 
      */
     public function delete( $filePath )
     {
+        $objects = array();
+        foreach ( (array)$filePath as $filePath )
+        {
+            $objects[] = array( 'Key' => $filePath );
+        }
+
         try
         {
-            $this->s3client->deleteObject(
+            // https://docs.aws.amazon.com/aws-sdk-php/v3/api/class-Aws.S3.S3Client.html
+            $this->s3client->deleteObjects(
                 array(
                     'Bucket' => $this->bucket,
-                    'Key' => $filePath,
+                    'Delete' => array( 'Objects' => $objects ),
                 )
             );
             return true;


### PR DESCRIPTION
> See ezsystems/ezdfs-fsbackend-dispatcher#4
> JIRA: https://jira.ez.no/browse/EZP-23171

Solves: issues when running cache clear or other code that triggers deletion of several cluster files at the same time.

Updated #3 for s3client v3 usage according to doc, and simplify to always use bulk way for simplicity. 
Not tested from my side, someone with access to a cluster will need to do that 👼😉


~Q: Could we also consider to use `deleteObjectsAsync()` here or is legacy expecting us to error out if wrong path is given or similar? _If we don't know for certain then we assume that might be the case of course._~ _skipped_


Closes #3